### PR TITLE
Refine base template — env fallbacks, services page, RUM fix

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,18 +2,30 @@
 NEXT_PUBLIC_SANITY_PROJECT_ID=     # From sanity.io/manage
 NEXT_PUBLIC_SANITY_DATASET=production
 NEXT_PUBLIC_SANITY_API_VERSION=2024-01-01
-SANITY_API_READ_TOKEN=             # Viewer role token
+SANITY_API_READ_TOKEN=*** Viewer role token
 
 # Site URL (used for sitemap, robots.txt, metadata)
 NEXT_PUBLIC_SITE_URL=              # https://yourdomain.com
 
+# Portal URL (for Sanity Studio / Visual Editing redirect)
+NEXT_PUBLIC_PORTAL_URL=            # https://portal.ctwebsiteco.com
+
 # Draft Mode
-DRAFT_MODE_SECRET=                 # Shared secret for CRM draft preview
+DRAFT_MODE_SECRET=*** Shared secret for CRM draft preview
 
 # Resend Email
-RESEND_API_KEY=                    # Domain-scoped sending key
+RESEND_API_KEY=*** Domain-scoped sending key
 CONTACT_FROM_EMAIL=                # noreply@yourdomain.com
 CONTACT_TO_EMAILS=                 # comma-separated recipients
 
 # Google Analytics
 NEXT_PUBLIC_GA_MEASUREMENT_ID=     # G-XXXXXXXXXX
+
+# RUM Analytics (web-vitals → CRM)
+NEXT_PUBLIC_RUM_TOKEN=             # From CRM dashboard
+
+# Company Info (used for static fallback content when Sanity is not configured)
+NEXT_PUBLIC_COMPANY_NAME=          # Your Business Name
+NEXT_PUBLIC_COMPANY_EMAIL=         # info@yourdomain.com
+NEXT_PUBLIC_COMPANY_PHONE=         # (555) 555-5555
+NEXT_PUBLIC_COMPANY_ADDRESS=       # City, State

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,9 +51,14 @@ export default async function RootLayout({
 }>) {
   const { isEnabled: isDraft } = await draftMode();
 
+  const companyName = process.env.NEXT_PUBLIC_COMPANY_NAME || "Business Name";
+  const companyEmail = process.env.NEXT_PUBLIC_COMPANY_EMAIL || "info@example.com";
+  const companyPhone = process.env.NEXT_PUBLIC_COMPANY_PHONE || "(555) 555-5555";
+  const companyAddress = process.env.NEXT_PUBLIC_COMPANY_ADDRESS || "City, State";
+
   return (
     <html lang="en" className={inter.variable}>
-      <body className="font-sans antialiased">
+      <body className="font-sans antialiased" style={{ "--company-name": companyName, "--company-email": companyEmail, "--company-phone": companyPhone, "--company-address": companyAddress } as React.CSSProperties}>
         <JsonLd />
         <SiteHeader />
         <main>{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,14 +12,14 @@ export default async function HomePage() {
     }
   }
 
-  const name = company?.name ?? "Business Name";
+  const name = company?.name ?? process.env.NEXT_PUBLIC_COMPANY_NAME ?? "Business Name";
   const tagline =
     company?.tagline ?? "Your trusted local service provider.";
   const description =
     company?.description ??
     "We provide high-quality services to residential and commercial customers. Contact us today for a free estimate.";
-  const phone = company?.phone ?? "(555) 555-5555";
-  const email = company?.email ?? "info@example.com";
+  const phone = company?.phone ?? process.env.NEXT_PUBLIC_COMPANY_PHONE ?? "(555) 555-5555";
+  const email = company?.email ?? process.env.NEXT_PUBLIC_COMPANY_EMAIL ?? "info@example.com";
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-16">

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { client } from "@/sanity/lib/client";
+import { createPageMetadata } from "@/lib/metadata";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Services",
+  description: "Learn about the services we offer to residential and commercial customers in the local area.",
+  path: "/services",
+});
+
+const SERVICES_QUERY = `*[_type == "service"][0...10] | order(orderRank asc) {
+  title,
+  description,
+  "icon": icon.asset->url
+}`;
+
+interface Service {
+  title: string;
+  description: string;
+  icon?: string;
+}
+
+export default async function ServicesPage() {
+  let services: Service[] = [];
+
+  if (client) {
+    try {
+      services = await client.fetch(SERVICES_QUERY) || [];
+    } catch {
+      // Sanity fetch failed — use fallback
+    }
+  }
+
+  // Static fallback when Sanity is not configured
+  if (!services.length) {
+    services = [
+      {
+        title: "Service Overview",
+        description: "We offer a comprehensive range of services tailored to meet your needs. Contact us today to discuss your project.",
+      },
+    ];
+  }
+
+  const companyName = process.env.NEXT_PUBLIC_COMPANY_NAME || "Business Name";
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-16">
+      <h1 className="text-4xl font-bold tracking-tight">Our Services</h1>
+      <p className="mt-4 text-xl text-muted-foreground">
+        Professional services for residential and commercial customers in the local area.
+      </p>
+
+      <div className="mt-12 grid gap-8 sm:grid-cols-2">
+        {services.map((service, i) => (
+          <div
+            key={i}
+            className="rounded-lg border bg-card p-6 shadow-sm"
+          >
+            <h2 className="text-xl font-semibold">{service.title}</h2>
+            <p className="mt-2 text-muted-foreground leading-relaxed">
+              {service.description}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-16 text-center">
+        <p className="text-muted-foreground">
+          Ready to get started?{" "}
+          <a href="/contact" className="text-primary hover:underline">
+            Contact us
+          </a>{" "}
+          for a free estimate.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -15,20 +15,24 @@ export async function JsonLd() {
   }
 
   const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com";
+  const companyName = company?.name || process.env.NEXT_PUBLIC_COMPANY_NAME || "Business Name";
+  const companyDescription =
+    company?.description ||
+    "Local business providing quality services to the community.";
+  const companyPhone = company?.phone || process.env.NEXT_PUBLIC_COMPANY_PHONE || "(555) 555-5555";
+  const companyEmail = company?.email || process.env.NEXT_PUBLIC_COMPANY_EMAIL || undefined;
 
   const schema: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
-    name: company?.name || "Business Name",
-    description:
-      company?.description ||
-      "Local business providing quality services to the community.",
+    name: companyName,
+    description: companyDescription,
     url: BASE_URL,
-    telephone: company?.phone || "(555) 555-5555",
+    telephone: companyPhone,
   };
 
-  if (company?.email) {
-    schema.email = company.email;
+  if (companyEmail) {
+    schema.email = companyEmail;
   }
 
   if (company?.address) {

--- a/components/rum-client.tsx
+++ b/components/rum-client.tsx
@@ -21,7 +21,7 @@ function getConnectionType(): string {
 
 export function RumClient() {
   useEffect(() => {
-    const token = process.env.NEXT_PUBLIC_RUM_TOKEN || ""
+    const token = process.env.NEXT_PUBLIC_RUM_TOKEN
     if (!token) return
 
     import("web-vitals").then(({ onCLS, onFCP, onINP, onLCP, onTTFB }) => {

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,11 +1,26 @@
-// TODO: Replace with site footer
 export function SiteFooter() {
+  const companyName = process.env.NEXT_PUBLIC_COMPANY_NAME || "Business Name";
+  const companyEmail = process.env.NEXT_PUBLIC_COMPANY_EMAIL || "info@example.com";
+  const companyPhone = process.env.NEXT_PUBLIC_COMPANY_PHONE || "(555) 555-5555";
+
   return (
     <footer className="border-t bg-background py-8" data-testid="site-footer">
-      <div className="mx-auto max-w-6xl px-4 text-center text-sm text-muted-foreground">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-4 px-4 text-center text-sm text-muted-foreground md:flex-row md:justify-between">
         <p>
-          &copy; {new Date().getFullYear()} Business Name. All rights reserved.
+          &copy; {new Date().getFullYear()} {companyName}. All rights reserved.
         </p>
+        <div className="flex gap-4">
+          {companyPhone && (
+            <a href={`tel:${companyPhone.replace(/\D/g, "")}`} className="hover:text-foreground">
+              {companyPhone}
+            </a>
+          )}
+          {companyEmail && (
+            <a href={`mailto:${companyEmail}`} className="hover:text-foreground">
+              {companyEmail}
+            </a>
+          )}
+        </div>
       </div>
     </footer>
   );

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,19 +1,19 @@
 import Link from "next/link";
 
-// TODO: Replace with site navigation
+// Navigation links — add site-specific routes here
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/contact", label: "Contact" },
-  // Add site-specific nav links
 ];
 
 export function SiteHeader() {
+  const companyName = process.env.NEXT_PUBLIC_COMPANY_NAME || "Business Name";
+
   return (
     <header className="border-b bg-background" data-testid="site-header">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
         <Link href="/" className="text-lg font-bold">
-          {/* TODO: Replace with company name or logo */}
-          Business Name
+          {companyName}
         </Link>
         <nav className="hidden gap-6 md:flex">
           {navLinks.map((link) => (

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import companyInfo from "./companyInfo";
 import emailTemplates from "./emailTemplates";
+import service from "./service";
 import seo from "./objects/seo";
 import imageWithAlt from "./objects/imageWithAlt";
 import sectionHeader from "./objects/sectionHeader";
@@ -8,6 +9,7 @@ export const schemaTypes = [
   // Document types
   companyInfo,
   emailTemplates,
+  service,
   // Object types
   seo,
   imageWithAlt,

--- a/sanity/schemas/service.ts
+++ b/sanity/schemas/service.ts
@@ -1,0 +1,45 @@
+import { defineType, defineField } from "sanity";
+
+export default defineType({
+  name: "service",
+  title: "Service",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Service Title",
+      type: "string",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "text",
+      rows: 4,
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "icon",
+      title: "Icon",
+      type: "image",
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: "orderRank",
+      title: "Display Order",
+      type: "string",
+    }),
+    defineField({
+      name: "seo",
+      title: "SEO",
+      type: "seo",
+    }),
+  ],
+  orderings: [
+    {
+      title: "Display Order",
+      name: "orderRank",
+      by: [{ field: "orderRank", direction: "asc" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Changes

### Environment-driven fallbacks
Added `NEXT_PUBLIC_COMPANY_*` env vars so sites work without Sanity configured:
- `NEXT_PUBLIC_COMPANY_NAME` — used in SiteHeader, SiteFooter, page fallbacks
- `NEXT_PUBLIC_COMPANY_EMAIL` — used in footer, homepage
- `NEXT_PUBLIC_COMPANY_PHONE` — used in footer, homepage
- `NEXT_PUBLIC_COMPANY_ADDRESS` — used in layout

### Components updated
- **SiteHeader**: now reads `NEXT_PUBLIC_COMPANY_NAME` instead of hardcoded "Business Name"
- **SiteFooter**: now shows company name + phone/email links, responsive layout
- **app/page.tsx**: all contact fields fall back to `NEXT_PUBLIC_*` vars
- **app/layout.tsx**: passes company info as CSS properties to body
- **rum-client.tsx**: removed `|| ""` fallback on `NEXT_PUBLIC_RUM_TOKEN` (token is truthy when set)
- **json-ld.tsx**: uses `NEXT_PUBLIC_COMPANY_*` as final fallback after Sanity/company data

### New: Services page
- `app/services/page.tsx` — lists services from Sanity (ordered by `orderRank`), with static fallback
- `sanity/schemas/service.ts` — Service content type with title, description, icon, orderRank, seo
- Registered in `sanity/schemas/index.ts`

### Documentation
- `.env.local.example` updated with all vars including `NEXT_PUBLIC_RUM_TOKEN`, `NEXT_PUBLIC_PORTAL_URL`, and all company vars

### Testing checklist
- [ ] Sites without Sanity configured still render company name/contact from env vars
- [ ] `pnpm build` succeeds
- [ ] `pnpm lint` passes
- [ ] Contact form still works with Sanity email templates
- [ ] RUM metrics fire correctly when `NEXT_PUBLIC_RUM_TOKEN` is set